### PR TITLE
Add null check before saving image to prevent panic

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1366,6 +1366,11 @@ fn gen_img_maybe_progress(
                 .iter()
                 .zip(files)
             {
+                // img.data will be null on OOM or other generation errors,
+                // in which case we skip saving and just return an error
+                if img.data.is_null() {
+                    return Err(DiffusionError::Forward);
+                }
                 match upscale(model_config.upscale_repeats, upscaler_ctx, *img) {
                     Ok(img) => save_img(img, &path, Some(&params_str))?,
                     Err(err) => {


### PR DESCRIPTION
This pull request adds an error check to handle out-of-memory (OOM) and other image generation errors in the `gen_img_maybe_progress` function. The function now returns an error if the generated image data is null, preventing further processing or saving of invalid images.

Error handling improvements:

* Added a check to return a `DiffusionError::Forward` if `img.data` is null, which can occur on OOM or other generation errors, ensuring invalid images are not saved or processed further in `gen_img_maybe_progress` (`src/api.rs`).